### PR TITLE
Add no-arg constructors to entities

### DIFF
--- a/src/main/java/com/qa/dodgy/persistence/domain/Movie.java
+++ b/src/main/java/com/qa/dodgy/persistence/domain/Movie.java
@@ -18,6 +18,10 @@ public class Movie {
 	private String actors;
 	private String reviews;
 	
+	public Movie() {
+		super();
+	}
+	
 	public Long getId() {
 		return id;
 	}

--- a/src/main/java/com/qa/dodgy/persistence/domain/Screen.java
+++ b/src/main/java/com/qa/dodgy/persistence/domain/Screen.java
@@ -14,6 +14,10 @@ public class Screen {
 	private String screenNumber;
 	private String screenType;
 	
+	public Screen() {
+		super();
+	}
+
 	public Long getId() {
 		return id;
 	}


### PR DESCRIPTION
Because `Movie` and `Screen` will likely have other constructors in the future, it is risky to rely on the default constructor for their instantiation, so they've been created manually.